### PR TITLE
fix (NFRMTCS-336): Fill problem content with valid HTML stub if empty

### DIFF
--- a/src/app/pages/contest/contest-task/content/content.component.ts
+++ b/src/app/pages/contest/contest-task/content/content.component.ts
@@ -14,4 +14,12 @@ import {
 })
 export class ContentComponent {
     @Input() content = '';
+    
+    ngAfterContentChecked() { 
+        // When task has no content, replace empty string
+        // with minimal valid HTML as ng-katex expects valid HTML
+        if (this.content === '') {
+            this.content = '<div class="problem-statement"></div>';
+        }
+    }
 }

--- a/src/app/pages/monitor/monitor-container/monitor.service.ts
+++ b/src/app/pages/monitor/monitor-container/monitor.service.ts
@@ -57,6 +57,7 @@ const memoContest = () => {
         }
 
         contests[id] = currentContest;
+
         return currentContest.results;
     };
 };

--- a/src/app/pages/monitor/monitor-container/monitor.service.ts
+++ b/src/app/pages/monitor/monitor-container/monitor.service.ts
@@ -57,7 +57,6 @@ const memoContest = () => {
         }
 
         contests[id] = currentContest;
-
         return currentContest.results;
     };
 };
@@ -66,10 +65,15 @@ const formatProblems = (contests: IContestApi[]): ITableProblem[] =>
     contests
         .sort((contest1, contest2) => contest1.position - contest2.position)
         .reduce((memo: ITableProblem[], contest) => {
+            contest.statement.problems.sort ((a, b)=>{
+                return a.rank - b.rank;
+            })
             contest.statement.problems.forEach((problem, index: number) => {
                 memo.push({
-                    contestId: contest.id,
                     id: problem.id,
+                    rank: problem.rank,
+                    contestId: contest.id,
+                    contestPosition: contest.position,
                     name: `${contest.position + 1}${formatLetter(index)}`,
                     detailed: {
                         fullname: `Задача №${problem.id}. ${problem.name}`,

--- a/src/app/pages/monitor/monitor-container/monitor.types.ts
+++ b/src/app/pages/monitor/monitor-container/monitor.types.ts
@@ -41,8 +41,10 @@ export interface IMonitorApi {
 
 export interface ITableProblem {
     contestId: number;
+    contestPosition: number;
     id: number;
     name: string;
+    rank: number;
     detailed: {
         fullname: string;
         contestName: string;


### PR DESCRIPTION
When task has no content, replace empty string with minimal valid HTML as ng-katex expects valid HTML